### PR TITLE
Use uncached SSM-backed state routes

### DIFF
--- a/app/api/states/active/route.ts
+++ b/app/api/states/active/route.ts
@@ -1,60 +1,51 @@
 // app/api/states/active/route.ts
-export const runtime = 'nodejs'; // critical: avoid Edge runtime
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 import { NextResponse } from 'next/server';
-import { SSMClient, GetParametersCommand, GetParametersByPathCommand } from '@aws-sdk/client-ssm';
+import { SSMClient, GetParametersCommand } from '@aws-sdk/client-ssm';
 
 const REGION = process.env.AWS_REGION || 'us-west-2';
-
-// Option A: keep your explicit list (matches your current approach)
 const ALL_STATES = ['CA', 'MT', 'IL', 'MO', 'OK', 'NY'];
 
 const ssm = new SSMClient({
   region: REGION,
-  credentials: process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY
-    ? {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-      }
-    : undefined, // let default provider chain handle it if unset
+  credentials:
+    process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY
+      ? {
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+        }
+      : undefined,
 });
 
 export async function GET() {
   try {
-    // --- Option A: using GetParameters with explicit names ---
-    const Names = ALL_STATES.map(s => `/green-pages/states/${s}/active`);
+    const Names = ALL_STATES.map((s) => `/green-pages/states/${s}/active`);
     const { Parameters = [] } = await ssm.send(
-      new GetParametersCommand({
-        Names,
-        WithDecryption: true,
-      })
+      new GetParametersCommand({ Names, WithDecryption: true })
     );
 
-    const activeStates = ALL_STATES.filter(s => {
-      const p = Parameters.find(p => p.Name === `/green-pages/states/${s}/active`);
-      // default to true when missing or not "false"
-      return p?.Value !== 'false';
+    const activeStates = ALL_STATES.filter((s) => {
+      const p = Parameters.find((p) => p.Name === `/green-pages/states/${s}/active`);
+      return p?.Value !== 'false'; // treat missing or anything else as active
     });
 
-    return NextResponse.json(activeStates, { status: 200 });
-
-    // --- Option B (alternative): dynamic by path ---
-    // const out = await ssm.send(new GetParametersByPathCommand({
-    //   Path: '/green-pages/states/',
-    //   WithDecryption: true,
-    //   Recursive: true,
-    // }));
-    // const map = new Map(out.Parameters?.map(p => [p.Name!, p.Value]) ?? []);
-    // const active = [];
-    // for (const [name, value] of map) {
-    //   if (name.endsWith('/active') && value !== 'false') {
-    //     active.push(name.split('/')[3]); // /green-pages/states/{STATE}/active
-    //   }
-    // }
-    // return NextResponse.json(active, { status: 200 });
-  } catch (err: any) {
-    console.error('Error fetching active states:', err);
-    // Safe fallback: treat all as active on error
-    return NextResponse.json(ALL_STATES, { status: 200 });
+    return NextResponse.json(activeStates, {
+      headers: {
+        'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+        'CDN-Cache-Control': 'no-store',
+        'Vercel-CDN-Cache-Control': 'no-store',
+      },
+    });
+  } catch {
+    return NextResponse.json(ALL_STATES, {
+      headers: {
+        'Cache-Control': 'no-store',
+        'CDN-Cache-Control': 'no-store',
+        'Vercel-CDN-Cache-Control': 'no-store',
+      },
+    });
   }
 }

--- a/app/components/ActiveStates.tsx
+++ b/app/components/ActiveStates.tsx
@@ -1,0 +1,24 @@
+// app/components/ActiveStates.tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function ActiveStates() {
+  const [states, setStates] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = async () => {
+    setLoading(true);
+    const res = await fetch('/api/states/active', { cache: 'no-store' });
+    const data = await res.json();
+    setStates(data);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  if (loading) return <div>Loading states…</div>;
+  return <div>Active states: {states.join(', ')}</div>;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import type React from "react"
 import { useEffect, useRef } from "react"
 import { useState } from "react"
 import { Facebook, Twitter, Instagram } from "lucide-react"
+import ActiveStates from "./components/ActiveStates"
 
 export default function USAAdvertisingPlatform() {
   const [currentStep, setCurrentStep] = useState(0)
@@ -93,6 +94,7 @@ export default function USAAdvertisingPlatform() {
 
       {/* Main Content */}
       <main className="flex-1 p-6">
+        <ActiveStates />
         {currentStep === 0 && <LocationStep onStateSelect={setSelectedState} />}
         {currentStep === 1 && (
           <div className="max-w-6xl mx-auto">
@@ -206,7 +208,7 @@ function LocationStep({ onStateSelect }: { onStateSelect: (state: string) => voi
   useEffect(() => {
     const fetchActiveStates = async () => {
       try {
-        const response = await fetch('/api/states/active')
+        const response = await fetch('/api/states/active', { cache: 'no-store' })
         if (response.ok) {
           const states = await response.json()
           setActiveStates(states)


### PR DESCRIPTION
## Summary
- Serve active state list from Node runtime and mark API responses as uncacheable
- Enforce Node runtime and default region on state toggle route
- Add ActiveStates client component and ensure client fetches bypass cache

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68c0921e9f3c8323b3f418e69fb62217